### PR TITLE
fix: stabilize 0.8.0

### DIFF
--- a/scripts/dist/types/index.d.ts
+++ b/scripts/dist/types/index.d.ts
@@ -1,3 +1,2 @@
 /// <reference types="../../types/chai" />
 export * from './types';
-export * from './client/addon/withCreevey';

--- a/src/client/addon/withCreevey.ts
+++ b/src/client/addon/withCreevey.ts
@@ -15,7 +15,7 @@ import {
   StorybookGlobals,
   StoryInput,
 } from '../../types';
-import { denormalizeStoryParameters } from '../../shared';
+import { denormalizeStoryParameters, serializeRawStories } from '../../shared';
 import { getConnectionUrl } from '../shared/helpers';
 
 if (typeof process != 'object' || typeof process.version != 'string') {
@@ -181,7 +181,11 @@ export function withCreevey(): MakeDecoratorResult {
 
   async function getStories(): Promise<StoriesRaw | void> {
     const storiesPromise = new Promise<StoriesRaw>((resolve) =>
-      addons.getChannel().once(Events.SET_STORIES, (data: SetStoriesData) => resolve(denormalizeStoryParameters(data))),
+      addons
+        .getChannel()
+        .once(Events.SET_STORIES, (data: SetStoriesData) =>
+          resolve(serializeRawStories(denormalizeStoryParameters(data))),
+        ),
     );
 
     const store = window.__STORYBOOK_STORY_STORE__ ?? {};
@@ -199,7 +203,7 @@ export function withCreevey(): MakeDecoratorResult {
       // TODO Figure out how to get only updated stories
       // TODO Subscribe on hmr? like use dummy-hmr
       setStoriesCounter += 1;
-      const stories = denormalizeStoryParameters(data);
+      const stories = serializeRawStories(denormalizeStoryParameters(data));
       const storiesByFiles = new Map<string, StoryInput[]>();
       Object.values(stories).forEach((story) => {
         const storiesFromFile = storiesByFiles.get(story.parameters.fileName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
 export * from './types';
-export * from './client/addon/withCreevey';
-export * from './client/addon/readyForCapture';
 export { loadStories as browserStoriesProvider } from './server/storybook/providers/browser';
 export { loadStories as nodejsStoriesProvider } from './server/storybook/providers/nodejs';

--- a/src/server/selenium/browser.ts
+++ b/src/server/selenium/browser.ts
@@ -421,9 +421,7 @@ async function selectStory(
   waitForReady = false,
 ): Promise<boolean> {
   browserLogger.debug(`Triggering 'SetCurrentStory' event with storyId ${chalk.magenta(id)}`);
-  const [errorMessage, isCaptureCalled = false] = await browser.executeAsyncScript<
-    [error?: string | null, isCaptureCalled?: boolean]
-  >(
+  const result = await browser.executeAsyncScript<[error?: string | null, isCaptureCalled?: boolean] | null>(
     function (
       id: string,
       kind: string,
@@ -443,6 +441,9 @@ async function selectStory(
     name,
     waitForReady,
   );
+
+  const [errorMessage, isCaptureCalled = false] = result ?? [];
+
   if (errorMessage) throw new Error(errorMessage);
 
   return isCaptureCalled;

--- a/src/server/selenium/browser.ts
+++ b/src/server/selenium/browser.ts
@@ -499,7 +499,8 @@ async function resolveCreeveyHost(browser: WebDriver, port: number): Promise<str
     function (hosts: string[], port: number, callback: (host?: string | null) => void) {
       void Promise.all(
         hosts.map(function (host) {
-          return fetch(`http://${host}:${port}/ping`)
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+          return fetch('http://' + host + ':' + port + '/ping')
             .then(function (response) {
               return response.text();
             })

--- a/src/server/selenium/browser.ts
+++ b/src/server/selenium/browser.ts
@@ -565,8 +565,7 @@ export async function getBrowser(config: Config, name: string): Promise<WebDrive
   const realAddress = address;
 
   // TODO Define some capabilities explicitly and define typings
-  const capabilities = new Capabilities(userCapabilities);
-  capabilities.setPageLoadStrategy(PageLoadStrategy.NONE);
+  const capabilities = new Capabilities({ ...userCapabilities, pageLoadStrategy: PageLoadStrategy.NONE });
 
   subscribeOn('shutdown', () => {
     browser?.quit().finally(() =>

--- a/src/server/stories.ts
+++ b/src/server/stories.ts
@@ -20,17 +20,18 @@ import { isStorybookVersionLessThan } from './storybook/helpers';
 function storyTestFabric(delay?: number, testFn?: CreeveyTestFunction) {
   return async function storyTest(this: Context) {
     delay ? await new Promise((resolve) => setTimeout(resolve, delay)) : void 0;
-    await (testFn?.call(this) ?? this.screenshots.length > 0
-      ? this.expect(
-          this.screenshots.reduce(
-            (screenshots, { imageName, screenshot }, index) => ({
-              ...screenshots,
-              [imageName ?? `screenshot_${index}`]: screenshot,
-            }),
-            {},
-          ),
-        ).to.matchImages()
-      : this.expect(await this.takeScreenshot()).to.matchImage());
+    await (testFn?.call(this) ??
+      (this.screenshots.length > 0
+        ? this.expect(
+            this.screenshots.reduce(
+              (screenshots, { imageName, screenshot }, index) => ({
+                ...screenshots,
+                [imageName ?? `screenshot_${index}`]: screenshot,
+              }),
+              {},
+            ),
+          ).to.matchImages()
+        : this.expect(await this.takeScreenshot()).to.matchImage()));
   };
 }
 

--- a/src/server/stories.ts
+++ b/src/server/stories.ts
@@ -20,18 +20,19 @@ import { isStorybookVersionLessThan } from './storybook/helpers';
 function storyTestFabric(delay?: number, testFn?: CreeveyTestFunction) {
   return async function storyTest(this: Context) {
     delay ? await new Promise((resolve) => setTimeout(resolve, delay)) : void 0;
-    testFn?.call(this) ??
-      (this.screenshots.length > 0
-        ? this.expect(
-            this.screenshots.reduce(
-              (screenshots, { imageName, screenshot }, index) => ({
-                ...screenshots,
-                [imageName ?? `screenshot_${index}`]: screenshot,
-              }),
-              {},
-            ),
-          ).to.matchImages()
-        : this.expect(await this.takeScreenshot()).to.matchImage());
+    await (testFn
+      ? testFn.call(this)
+      : this.screenshots.length > 0
+      ? this.expect(
+          this.screenshots.reduce(
+            (screenshots, { imageName, screenshot }, index) => ({
+              ...screenshots,
+              [imageName ?? `screenshot_${index}`]: screenshot,
+            }),
+            {},
+          ),
+        ).to.matchImages()
+      : this.expect(await this.takeScreenshot()).to.matchImage());
   };
 }
 

--- a/src/server/stories.ts
+++ b/src/server/stories.ts
@@ -20,7 +20,7 @@ import { isStorybookVersionLessThan } from './storybook/helpers';
 function storyTestFabric(delay?: number, testFn?: CreeveyTestFunction) {
   return async function storyTest(this: Context) {
     delay ? await new Promise((resolve) => setTimeout(resolve, delay)) : void 0;
-    await (testFn?.call(this) ??
+    testFn?.call(this) ??
       (this.screenshots.length > 0
         ? this.expect(
             this.screenshots.reduce(
@@ -31,7 +31,7 @@ function storyTestFabric(delay?: number, testFn?: CreeveyTestFunction) {
               {},
             ),
           ).to.matchImages()
-        : this.expect(await this.takeScreenshot()).to.matchImage()));
+        : this.expect(await this.takeScreenshot()).to.matchImage());
   };
 }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,6 +1,6 @@
 import { Parameters } from '@storybook/api';
-import { mapValues, mergeWith } from 'lodash';
-import { SetStoriesData, StoriesRaw } from './types';
+import { mapValues, mergeWith, cloneDeepWith } from 'lodash';
+import { SetStoriesData, StoriesRaw, CreeveyStoryParams, StoryInput } from './types';
 
 // NOTE: Copy-paste from storybook/api
 export const combineParameters = (...parameterSets: Parameters[]): Parameters =>
@@ -26,4 +26,77 @@ export const denormalizeStoryParameters = ({
       storyData.parameters as Parameters,
     ),
   })) as StoriesRaw;
+};
+
+interface SerializedRegExp {
+  __regexp: true;
+  source: string;
+  flags: string;
+}
+
+export const isSerializedRegExp = (exp: unknown): exp is SerializedRegExp => {
+  return typeof exp === 'object' && exp !== null && Reflect.get(exp, '__regexp') === true;
+};
+
+export const serializeRegExp = (exp: RegExp): SerializedRegExp => {
+  const { source, flags } = exp;
+  return {
+    __regexp: true,
+    source,
+    flags,
+  };
+};
+
+export const deserializeRegExp = ({ source, flags }: SerializedRegExp): RegExp => {
+  return new RegExp(source, flags);
+};
+
+export const serializeRawStories = (stories: StoriesRaw): StoriesRaw => {
+  return mapValues(stories, (storyData) => {
+    const creevey = storyData.parameters.creevey as CreeveyStoryParams | undefined;
+    if (creevey?.skip) {
+      return {
+        ...storyData,
+        parameters: {
+          ...storyData.parameters,
+          creevey: {
+            ...creevey,
+            skip: cloneDeepWith(creevey.skip, (value) => {
+              if (value instanceof RegExp) {
+                return serializeRegExp(value);
+              }
+              return undefined;
+            }) as CreeveyStoryParams['skip'],
+          },
+        },
+      };
+    }
+    return storyData;
+  });
+};
+
+export const deserializeRawStories = (stories: StoriesRaw): StoriesRaw => {
+  return mapValues(stories, deserializeStory);
+};
+
+export const deserializeStory = (story: StoryInput): StoryInput => {
+  const creevey = story.parameters.creevey as CreeveyStoryParams | undefined;
+  if (creevey?.skip) {
+    return {
+      ...story,
+      parameters: {
+        ...story.parameters,
+        creevey: {
+          ...creevey,
+          skip: cloneDeepWith(creevey.skip, (value) => {
+            if (isSerializedRegExp(value)) {
+              return deserializeRegExp(value);
+            }
+            return undefined;
+          }) as CreeveyStoryParams['skip'],
+        },
+      },
+    };
+  }
+  return story;
 };

--- a/src/shared/serializeRegExp.ts
+++ b/src/shared/serializeRegExp.ts
@@ -1,0 +1,26 @@
+export interface SerializedRegExp {
+  __regexp: true;
+  source: string;
+  flags: string;
+}
+
+export const isRegExp = (exp: unknown): exp is RegExp => {
+  return exp instanceof RegExp;
+};
+
+export const isSerializedRegExp = (exp: unknown): exp is SerializedRegExp => {
+  return typeof exp === 'object' && exp !== null && Reflect.get(exp, '__regexp') === true;
+};
+
+export const serializeRegExp = (exp: RegExp): SerializedRegExp => {
+  const { source, flags } = exp;
+  return {
+    __regexp: true,
+    source,
+    flags,
+  };
+};
+
+export const deserializeRegExp = ({ source, flags }: SerializedRegExp): RegExp => {
+  return new RegExp(source, flags);
+};

--- a/tests/shared/serializeRawStories.test.ts
+++ b/tests/shared/serializeRawStories.test.ts
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import { CreeveyStoryParams, StoriesRaw } from '../../src/types';
+import { serializeRawStories, deserializeRawStories } from '../../src/shared';
+
+describe('serializes raw stories with creevey params', () => {
+  const getStories = (): StoriesRaw => {
+    const creeveyParams: CreeveyStoryParams = {
+      captureElement: 'body',
+      ignoreElements: ['button', '#ignore-me'],
+      skip: {
+        legacy: { in: 'browser' },
+        flacky: { stories: new RegExp('button', 'i'), tests: /click/gi },
+      },
+    };
+
+    return {
+      'test-story': {
+        id: 'test-story',
+        name: 'story',
+        kind: 'test',
+        parameters: {
+          fileName: '',
+          options: {},
+          creevey: creeveyParams,
+        },
+      },
+    };
+  };
+
+  it('serializes and deserializes without losses', () => {
+    const stories = getStories();
+    const serialized = serializeRawStories(stories);
+    const deserialized = deserializeRawStories(serialized);
+
+    expect(deserialized).to.deep.equal(stories);
+  });
+
+  it('serializes, stringifies, parses and deserializes without losses', () => {
+    const stories = getStories();
+    const serialized = serializeRawStories(stories);
+    const stringified = JSON.stringify(serialized);
+    const parsed = JSON.parse(stringified) as StoriesRaw;
+    const deserialized = deserializeRawStories(parsed);
+
+    expect(deserialized).to.deep.equal(stories);
+  });
+});

--- a/tests/shared/serializeRegExp.test.ts
+++ b/tests/shared/serializeRegExp.test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { serializeRegExp, deserializeRegExp, SerializedRegExp } from '../../src/shared/serializeRegExp';
+
+describe('serialize regexp', () => {
+  it('serializes correctly', () => {
+    const regexp = /[a-z]/gi;
+    const serialized: SerializedRegExp = {
+      __regexp: true,
+      source: '[a-z]',
+      flags: 'gi',
+    };
+    expect(serializeRegExp(regexp)).to.deep.equal(serialized);
+  });
+
+  it('deserializes correctly', () => {
+    const regexp = /[a-z]/gi;
+    const serialized: SerializedRegExp = {
+      __regexp: true,
+      source: '[a-z]',
+      flags: 'gi',
+    };
+    expect(deserializeRegExp(serialized)).to.deep.equal(regexp);
+  });
+});


### PR DESCRIPTION
Hi,

#187 introduced several bugs that i found while working on #228. I grouped fixes for them here.

In the commits order:

1. A wrong operations order while calling the test function. It's caused by `??` operator taking precedence over the ternary.
2. `@storybook/testing-library` started getting imported to the addon. It contains [some browser-specific code](https://github.com/storybookjs/storybook/blob/next/code/lib/instrumenter/src/instrumenter.ts#L620).  And the addon is being exported from the index. This produces warnings while running Creevey in Node.
3. IE11 can't do template literals. It also doesn't have `fetch`, it can be polyfilled by user.
4. This actually isn't related to the 187. But it's necessary to be able to specify timeouts via capabilities. Other way they get overrided.
5. RegExps doesn't get serialized correctly while transferring from browser to Node. It's critical for creevey extracting Creevey parameters.
6. I'm still investigating this. In my project with Storybook 6.3 `browser.executeAsyncScript` returns `null` there.
----

Creevey tests will recover when #227 is merged.