### PR TITLE
fix: move the addon to a separate entry point

### DIFF
--- a/addon/README.md
+++ b/addon/README.md
@@ -1,0 +1,3 @@
+This is a fallback for package.json's `exports.addon` field. It's required for outdated environments (like node 11 and typescript with the "node" moduleResolution) to resolve imports from `creevey/addon` properly.
+
+See https://github.com/andrewbranch/example-subpath-exports-ts-compat. The fallback uses the "package-json-redirects" startegy.

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../lib/cjs/client/addon/index.js",
+  "types": "../lib/types/client/addon/index.d.ts"
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,12 @@
   "bin": {
     "creevey": "./lib/cjs/cli.js"
   },
+  "exports": {
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "default": "./lib/cjs/index.js"
+    }
+  },
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     ".": {
       "types": "./lib/types/index.d.ts",
       "default": "./lib/cjs/index.js"
+    },
+    "./addon": {
+      "types": "./lib/types/client/addon/index.d.ts",
+      "default": "./lib/cjs/client/addon/index.js"
     }
   },
   "main": "lib/cjs/index.js",

--- a/scripts/dist/types/index.d.ts
+++ b/scripts/dist/types/index.d.ts
@@ -1,3 +1,2 @@
 /// <reference types="../../types/chai" />
 export * from './types';
-export * from './client/addon/withCreevey';

--- a/src/client/addon/index.ts
+++ b/src/client/addon/index.ts
@@ -1,0 +1,2 @@
+export * from './withCreevey';
+export * from './readyForCapture';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
 export * from './types';
-export * from './client/addon/withCreevey';
-export * from './client/addon/readyForCapture';
 export { loadStories as browserStoriesProvider } from './server/storybook/providers/browser';
 export { loadStories as nodejsStoriesProvider } from './server/storybook/providers/nodejs';

--- a/stories/ImagesViews.stories.mdx
+++ b/stories/ImagesViews.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 import { fireEvent, within } from '@storybook/testing-library';
 
-import { capture } from '../src/client/addon/withCreevey';
+import { capture } from '../src/client/addon';
 import { ImagesView as ImagesViewBase } from '../src/client/shared/components/ImagesView';
 import { ImagesViewMode, CSFStory } from '../src/types';
 

--- a/stories/ImagesViews.stories.tsx
+++ b/stories/ImagesViews.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
 import { fireEvent, within } from '@storybook/testing-library';
 
-import { capture } from '../src/client/addon/withCreevey';
+import { capture } from '../src/client/addon';
 import { ImagesView as ImagesViewBase } from '../src/client/shared/components/ImagesView';
 import { ImagesViewMode } from '../src/types';
 

--- a/stories/SlideView.stories.tsx
+++ b/stories/SlideView.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
 import { fireEvent, within } from '@storybook/testing-library';
 import { ImagesView as ImagesViewBase } from '../src/client/shared/components/ImagesView';
-import { capture } from '../src/client/addon/withCreevey';
+import { capture } from '../src/client/addon';
 
 const SlideView = (image: { expect: string; diff: string; actual: string }): JSX.Element => (
   <ImagesViewBase image={image} url="https://images.placeholders.dev" canApprove mode={'slide'} />

--- a/stories/SwapView.stories.tsx
+++ b/stories/SwapView.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react';
 import { fireEvent, within } from '@storybook/testing-library';
 import { ImagesView as ImagesViewBase } from '../src/client/shared/components/ImagesView';
-import { capture } from '../src/client/addon/withCreevey';
+import { capture } from '../src/client/addon';
 
 const SwapView = (image: { expect: string; diff: string; actual: string }): JSX.Element => (
   <ImagesViewBase image={image} url="https://images.placeholders.dev" canApprove mode={'swap'} />

--- a/tests/server/master/loader.fixtures/addDecorator.input.tsx
+++ b/tests/server/master/loader.fixtures/addDecorator.input.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import React from 'react';
-import { withCreevey } from 'creevey';
+import { withCreevey } from 'creevey/addon';
 import { addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 

--- a/tests/server/master/loader.fixtures/preview-side-effects.input.tsx
+++ b/tests/server/master/loader.fixtures/preview-side-effects.input.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { configure, addDecorator, addParameters } from '@storybook/react';
-import { withCreevey } from 'creevey';
+import { withCreevey } from 'creevey/addon';
 import { hasChildren } from './helpers';
 
 const selector = '#root';


### PR DESCRIPTION
This started as p.2 of #226, but was extracted to a separate PR.

Since #187 the `@storybook/testing-library` started getting imported to the addon. It contains [some browser-specific code](https://github.com/storybookjs/storybook/blob/next/code/lib/instrumenter/src/instrumenter.ts#L620). And the addon is being exported from the index. This produces warnings while running Creevey in Node.

Moving the addon to a separate entry point was proposed in the [#226](https://github.com/creevey/creevey/pull/226#discussion_r975045715). But it requires adding a fallback for older environments that don't support the exports field. See [example-subpath-exports-ts-compat](https://github.com/andrewbranch/example-subpath-exports-ts-compat). This PR uses the [package-json-redirects](https://github.com/andrewbranch/example-subpath-exports-ts-compat/blob/main/examples/node_modules/package-json-redirects) fallback strategy as a fully backward compatible one.

Also: [TypeScript 4.7: package.json Exports, Imports, and Self-Referencing](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#ecmascript-module-support-in-node-js).

Successfully tested using next envs:
```
node: 16.15.0
typescript: 4.8.4 
moduleResolution: node16
```
```
node: 16.15.0
typescript: 4.5.4 
moduleResolution: node
```