### PR TITLE
fix: infinite UI loading

### DIFF
--- a/src/server/master/server.ts
+++ b/src/server/master/server.ts
@@ -102,7 +102,9 @@ export default function server(reportDir: string, port: number, ui: boolean): (a
     api.subscribe(wss);
 
     wss.on('connection', (ws) => {
-      ws.on('message', (message: WebSocket.Data) => api.handleMessage(ws, message));
+      ws.on('message', (message: WebSocket.RawData, isBinary: boolean) => {
+        api.handleMessage(ws, isBinary ? message : message.toString());
+      });
     });
   });
 


### PR DESCRIPTION
After updating `ws` from `7` to `8` in https://github.com/creevey/creevey/pull/221 the UI stopped working. It shows initial loader infinitly now. And a message started to appear in the console while opening it: `unhandled message ...`.

The reason is the [breaking change](https://github.com/websockets/ws/releases/tag/8.0.0) in `ws@8.0.0`:

> Text messages and close reasons are no longer decoded to strings. They are
passed as Buffers to the listeners of their respective events. The listeners
of the 'message' event now take a boolean argument specifying whether or not
the message is binary.

> 
> Existing code can be migrated by decoding the buffer explicitly.

```js
websocket.on('message', function message(data, isBinary) {
  const message = isBinary ? data : data.toString();
  // Continue as before.
});

```