### PR TITLE
fix(addon): restore IE11 support

### DIFF
--- a/src/client/addon/utils.tsx
+++ b/src/client/addon/utils.tsx
@@ -20,3 +20,5 @@ export function getEmojiByTestStatus(status: TestStatus | undefined, skip: strin
     }
   }
 }
+
+export const isInternetExplorer = navigator.userAgent.includes('Trident/');

--- a/src/client/addon/withCreevey.ts
+++ b/src/client/addon/withCreevey.ts
@@ -17,6 +17,7 @@ import {
 } from '../../types';
 import { denormalizeStoryParameters, serializeRawStories } from '../../shared';
 import { getConnectionUrl } from '../shared/helpers';
+import { isInternetExplorer } from './utils';
 
 if (typeof process != 'object' || typeof process.version != 'string') {
   // NOTE If you don't use babel-polyfill or any other polyfills that add EventSource for IE11
@@ -360,7 +361,9 @@ export function withCreevey(): MakeDecoratorResult {
             case captureElement === null:
               return Promise.resolve(document.documentElement);
             case typeof captureElement == 'string':
-              return within<typeof queries>(context.canvasElement, queries).findByQuery(captureElement as string);
+              return isInternetExplorer // some code from testing-library makes IE hang
+                ? Promise.resolve(context.canvasElement.querySelector(captureElement as string))
+                : within<typeof queries>(context.canvasElement, queries).findByQuery(captureElement as string);
             case typeof captureElement == 'function':
               // TODO Define type for it
               return Promise.resolve(


### PR DESCRIPTION
Hi,

Found another IE11 support breakdown after #187. 

The problem is somewhere inside testing-library, which causes a sort of infinit loop in IE11 and completly hang it. It's hard to debug any further, so I suggest a workaround. Since the broken feature is only about DX and nobody uses IE for development, it should be OK. 