### PR TITLE
feat: drop support of storybook < 6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ It named after [Colin Creevey](https://harrypotter.fandom.com/wiki/Colin_Creevey
 ## Pre-requisites
 
 - Make sure you have installed [Docker](https://www.docker.com/products/docker-desktop). But if you going to use your own separate Selenium Grid, you don't need `Docker`.
+- Supported Storybook versions: `^6.4.0`.
 
 ## How to start
 
@@ -149,6 +150,6 @@ Because tests defined in story parameters and `selenium-webdriver` depends on no
 | [![Whisk](https://raw.githubusercontent.com/wKich/creevey/master/.github/images/whisk.svg)](https://whisk.com/) | [![SKB Kontur](https://kontur.ru/Files/userfiles/image/brandbook/logo-skb-kontur-eng.png)](https://kontur.ru/) | [![ABBYY](https://raw.githubusercontent.com/wKich/creevey/master/.github/images/abbyy.svg)](https://www.abbyy.com/) |
 | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 
-
 ## License
+
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FwKich%2Fcreevey.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2FwKich%2Fcreevey?ref=badge_large)

--- a/src/client/addon/withCreevey.ts
+++ b/src/client/addon/withCreevey.ts
@@ -189,12 +189,7 @@ export function withCreevey(): MakeDecoratorResult {
     );
 
     const store = window.__STORYBOOK_STORY_STORE__ ?? {};
-    // @ts-expect-error `pushToManager` exists only in Storybook 6.0 - 6.3
-    if (store.pushToManager) {
-      // @ts-expect-error `pushToManager` exists only in Storybook 6.0 - 6.3
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      store.pushToManager();
-    } else if (store.cacheAllCSFFiles) {
+    if (store.cacheAllCSFFiles) {
       await store.cacheAllCSFFiles();
       addons.getChannel().emit(Events.SET_STORIES, store.getSetStoriesPayload());
     } else return;

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,11 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import {
-  isCSFv3Enabled,
-  isStorybookVersionGreaterThan,
-  isStorybookVersionLessThan,
-  storybookDirRef,
-} from './storybook/helpers';
+import { isCSFv3Enabled, storybookDirRef } from './storybook/helpers';
 import { loadStories as nodejsStoriesProvider } from './storybook/providers/nodejs';
 import { loadStories as browserStoriesProvider } from './storybook/providers/browser';
 import { Config, Browser, BrowserConfig, Options, isDefined } from '../types';
@@ -60,13 +55,8 @@ export async function readConfig(options: Options): Promise<Config> {
 
   storybookDirRef.current = userConfig.storybookDir;
 
-  if (isStorybookVersionLessThan(6, 2)) userConfig.useWebpackToExtractTests = true;
   if (!userConfig.storiesProvider)
-    userConfig.storiesProvider =
-      (await isCSFv3Enabled()) && isStorybookVersionGreaterThan(5) ? browserStoriesProvider : nodejsStoriesProvider;
-
-  if (userConfig.storiesProvider == browserStoriesProvider && isStorybookVersionLessThan(6))
-    throw new Error("Creevey browser stories provider doesn't support Storybook 5.x or older versions");
+    userConfig.storiesProvider = (await isCSFv3Enabled()) ? browserStoriesProvider : nodejsStoriesProvider;
 
   if (options.failFast != undefined) userConfig.failFast = Boolean(options.failFast);
   if (options.reportDir) userConfig.reportDir = path.resolve(options.reportDir);

--- a/src/server/extract.ts
+++ b/src/server/extract.ts
@@ -1,8 +1,6 @@
-import { denormalizeStoryParameters } from '../shared';
 import { Config, Options } from '../types';
 import { subscribeOn } from './messages';
 import { loadTestsFromStories, saveStoriesJson, saveTestsJson } from './stories';
-import { isStorybookVersionGreaterThan, isStorybookVersionLessThan } from './storybook/helpers';
 import { extractStoriesData } from './storybook/providers/nodejs';
 
 export default async function extract(config: Config, options: Options): Promise<void> {
@@ -22,10 +20,7 @@ export default async function extract(config: Config, options: Options): Promise
 
   const tests = await loadTestsFromStories(Object.keys(config.browsers), async () => {
     const data = await extractStoriesData(config, { watch: false, debug: options.debug });
-    const stories =
-      isStorybookVersionLessThan(6) || isStorybookVersionGreaterThan(6, 3)
-        ? data.stories
-        : denormalizeStoryParameters(data);
+    const stories = data.stories;
 
     if (options.extract) saveStoriesJson(data, options.extract);
 

--- a/src/server/loaders/babel/register.ts
+++ b/src/server/loaders/babel/register.ts
@@ -5,7 +5,7 @@ import { addHook } from 'pirates';
 import { Config, isDefined } from '../../../types';
 import { extensions } from '../../utils';
 import plugin from './creevey-plugin';
-import { hasDocsAddon, hasSvelteCSFAddon, isStorybookVersionLessThan } from '../../storybook/helpers';
+import { hasDocsAddon, hasSvelteCSFAddon } from '../../storybook/helpers';
 
 let parents: string[] | null = null;
 let story: string | null = null;
@@ -84,7 +84,7 @@ function getRequireContext(rootDir: string) {
 }
 
 export default async function register(config: Config, debug = false): Promise<ReturnType<typeof getRequireContext>> {
-  const rootDir = isStorybookVersionLessThan(6, 4) ? config.storybookDir : process.cwd();
+  const rootDir = process.cwd();
   const requireContext = getRequireContext(rootDir);
   const preview = resolve(config.storybookDir, 'preview');
 

--- a/src/server/loaders/webpack/creevey-loader.ts
+++ b/src/server/loaders/webpack/creevey-loader.ts
@@ -6,7 +6,6 @@ import { parse } from '@babel/parser';
 import traverse, { NodePath, Binding } from '@babel/traverse';
 import generate from '@babel/generator';
 import * as t from '@babel/types';
-import { isStorybookVersionLessThan } from '../../storybook/helpers';
 import { commonVisitor, mdxVisitor, previewVisitor, storyVisitor, FileType } from '../babel/helpers';
 import { logger } from '../../logger';
 import type { JSONSchema7 } from 'schema-utils/declarations/validate';
@@ -62,9 +61,6 @@ function isPreview(context: LoaderContext, options: Options | Readonly<OptionObj
   const { dir: resourceDir, name: resourceName } = path.posix.parse(toPosix(context.resourcePath));
   const storybookDir = typeof options.storybookDir == 'string' ? toPosix(options.storybookDir) : '';
   const isConfigFile = resourceDir == storybookDir && (resourceName == 'preview' || resourceName == 'config');
-  if (isStorybookVersionLessThan(6)) {
-    return isEntry(context) && isConfigFile;
-  }
   const issuerResource = getIssuerResource(context);
   return Boolean(issuerResource && entries.has(issuerResource) && isConfigFile);
 }

--- a/src/server/loaders/webpack/mdx-loader.ts
+++ b/src/server/loaders/webpack/mdx-loader.ts
@@ -2,11 +2,9 @@
 /* Copy-paste from storybook/addons/docs/src/frameworks/common/preset.ts */
 
 import {
-  isStorybookVersionLessThan,
   resolveFromStorybook,
   resolveFromStorybookAddonDocs,
   resolveFromStorybookBuilderWebpack4,
-  resolveFromStorybookCore,
 } from '../../storybook/helpers';
 
 export let mdxLoaders: any[] = [];
@@ -46,9 +44,7 @@ export function webpack(webpackConfig: any = {}, options: any = {}): any {
 
   mdxLoaders = [
     {
-      loader: isStorybookVersionLessThan(6, 2)
-        ? resolveFromStorybookCore('babel-loader')
-        : resolveFromStorybookBuilderWebpack4('babel-loader'),
+      loader: resolveFromStorybookBuilderWebpack4('babel-loader'),
       options: createBabelOptions({ babelOptions, mdxBabelOptions, configureJSX }),
     },
     {

--- a/src/server/selenium/browser.ts
+++ b/src/server/selenium/browser.ts
@@ -21,7 +21,7 @@ import {
 } from '../../types';
 import { colors, logger } from '../logger';
 import { emitStoriesMessage, subscribeOn } from '../messages';
-import { importStorybookCoreEvents, isStorybookVersionLessThan } from '../storybook/helpers';
+import { importStorybookCoreEvents } from '../storybook/helpers';
 import { isShuttingDown, LOCALHOST_REGEXP, runSequence } from '../utils';
 
 type ElementRect = {
@@ -147,16 +147,6 @@ function getUrlChecker(browser: WebDriver): (url: string) => Promise<boolean> {
 }
 
 async function waitForStorybook(browser: WebDriver): Promise<void> {
-  // NOTE: Storybook 5.x doesn't have the `last` method
-  if (isStorybookVersionLessThan(6)) {
-    browserLogger.debug('Waiting for `load` event to make sure that storybook is initiated');
-    return browser.executeAsyncScript(function (callback: () => void): void {
-      if (document.readyState == 'complete') return callback();
-      window.addEventListener('load', function () {
-        callback();
-      });
-    });
-  }
   browserLogger.debug('Waiting for `setStories` event to make sure that storybook is initiated');
   let wait = true;
   let isTimeout = false;
@@ -450,10 +440,6 @@ async function selectStory(
 }
 
 export async function updateStorybookGlobals(browser: WebDriver, globals: StorybookGlobals): Promise<void> {
-  if (isStorybookVersionLessThan(6)) {
-    browserLogger.warn('Globals are not supported by Storybook versions less than 6');
-    return;
-  }
   browserLogger.debug('Applying storybook globals');
   await browser.executeScript(function (globals: StorybookGlobals) {
     window.__CREEVEY_UPDATE_GLOBALS__(globals);

--- a/src/server/stories.ts
+++ b/src/server/stories.ts
@@ -15,7 +15,6 @@ import type {
 } from '../types';
 import { isDefined, isFunction, isObject } from '../types';
 import { shouldSkip, removeProps } from './utils';
-import { isStorybookVersionLessThan } from './storybook/helpers';
 
 function storyTestFabric(delay?: number, testFn?: CreeveyTestFunction) {
   return async function storyTest(this: Context) {
@@ -132,18 +131,16 @@ export async function loadTestsFromStories(
 export function saveStoriesJson(storiesData: SetStoriesData, extract: string | boolean): void {
   const outputDir = typeof extract == 'boolean' ? 'storybook-static' : extract;
 
-  if (!isStorybookVersionLessThan(6)) {
-    // NOTE Copy-pasted from Storybook's `getStoriesJsonData` method
-    const allowed = ['fileName', 'docsOnly', 'framework', '__id', '__isArgsStory'];
-    storiesData.globalParameters = pick(storiesData.globalParameters, allowed);
-    // @ts-expect-error ignore error
-    storiesData.kindParameters = mapValues(storiesData.kindParameters, (v) => pick(v, allowed));
-    // @ts-expect-error ignore error
-    storiesData.stories = mapValues(storiesData.stories, (v) => ({
-      ...pick(v, ['id', 'name', 'kind', 'story']),
-      parameters: pick(v.parameters, allowed),
-    }));
-  }
+  // NOTE Copy-pasted from Storybook's `getStoriesJsonData` method
+  const allowed = ['fileName', 'docsOnly', 'framework', '__id', '__isArgsStory'];
+  storiesData.globalParameters = pick(storiesData.globalParameters, allowed);
+  // @ts-expect-error ignore error
+  storiesData.kindParameters = mapValues(storiesData.kindParameters, (v) => pick(v, allowed));
+  // @ts-expect-error ignore error
+  storiesData.stories = mapValues(storiesData.stories, (v) => ({
+    ...pick(v, ['id', 'name', 'kind', 'story']),
+    parameters: pick(v.parameters, allowed),
+  }));
 
   // TODO Fix args stories
   removeProps(storiesData ?? {}, ['stories', () => true, 'parameters', '__isArgsStory']);

--- a/src/server/storybook/entry.ts
+++ b/src/server/storybook/entry.ts
@@ -1,22 +1,15 @@
 import type { StoryApi } from '@storybook/addons';
-import type { Channel } from '@storybook/channels';
 import { addons } from '@storybook/addons';
-import { getStorybookFramework, isStorybookVersionLessThan, resolveFromStorybook } from './helpers';
+import { getStorybookFramework, resolveFromStorybook } from './helpers';
 
 const framework = getStorybookFramework();
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const core = require(resolveFromStorybook('@storybook/core')) as typeof import('@storybook/core');
 
-//@ts-expect-error: 6.2 use named exports
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-const start = isStorybookVersionLessThan(6, 2) ? (core.default.start as typeof core.start) : core.start;
+const start = core.start;
 const api = start(() => void 0);
 
-export const channel = isStorybookVersionLessThan(6, 4)
-  ? //@ts-expect-error: 6.x has { channel }, but 5.x has { context: { channel } }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    ((api.channel ?? api.context?.channel) as Channel)
-  : addons.getChannel();
+export const channel = addons.getChannel();
 
 type ClientApi = ReturnType<typeof start>['clientApi'];
 
@@ -28,17 +21,6 @@ export const storiesOf = (kind: string, m: NodeModule): StoryApi => {
   });
 };
 export const configure = (...args: unknown[]): unknown => {
-  if (isStorybookVersionLessThan(5, 2)) {
-    //NOTE: Storybook <= 5.1 pass args as is
-    //@ts-expect-error: ignore it
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    return api.configApi.configure(...args);
-  }
-  if (isStorybookVersionLessThan(6)) {
-    //NOTE: Storybook <= 5.3 pass `framework` as last argument
-    //@ts-expect-error: ignore it
-    return api.configure(...args, framework);
-  }
   //NOTE Storybook 6.x pass `framework` as first argument
   //@ts-expect-error: ignore it
   return api.configure(framework, ...args);

--- a/src/server/storybook/helpers.ts
+++ b/src/server/storybook/helpers.ts
@@ -117,10 +117,8 @@ export async function importStorybookConfig(): Promise<StorybookConfig> {
       (await import(require.resolve(configPath))) as { default: StorybookConfig }
     ).default);
   } catch (_) {
-    const storybookUtilsPath = isStorybookVersionLessThan(6, 2)
-      ? '@storybook/core/dist/server/utils'
-      : '@storybook/core-common/dist/cjs/utils';
-    const serverRequireModule = isStorybookVersionLessThan(6, 2) ? 'server-require' : 'interpret-require';
+    const storybookUtilsPath = '@storybook/core-common/dist/cjs/utils';
+    const serverRequireModule = 'interpret-require';
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const { getInterpretedFile } = await import(resolveFromStorybook(`${storybookUtilsPath}/interpret-files`));
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -128,11 +126,8 @@ export async function importStorybookConfig(): Promise<StorybookConfig> {
       resolveFromStorybook(`${storybookUtilsPath}/${serverRequireModule}`)
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const mainConfigFile = isStorybookVersionLessThan(6, 1)
-      ? configPath
-      : // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        getInterpretedFile(configPath);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const mainConfigFile = getInterpretedFile(configPath);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     return (storybookConfigRef.current = serverRequire(mainConfigFile) as StorybookConfig);
   }


### PR DESCRIPTION
Hey,

as we decided in #236 we should drop support of storybook < 6.4 in order to fix the deps confict.

So, here I deleted all the code for older storybook's versions. And also documented the minimal supported one. 