### PR TITLE
fix: drop support of SkipOption on root skip level

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -120,7 +120,7 @@ export const parameters = {
   creevey: {
     // Skip all *hover tests in IE11 on the global level
     skip: {
-      ie11: { in: 'ie11', tests: /.*hover$/ },
+      "hovers don't work in ie11": { in: 'ie11', tests: /.*hover$/ },
     },
   },
 };
@@ -137,15 +137,14 @@ export default {
   parameters: {
     creevey: {
       // You could skip some browsers/stories or even specific tests
-      skip: [
-        { in: 'ie11', reason: "`MyComponent` doesn't support ie11" },
-        { in: 'firefox', stories: 'Loading', reason: "Loading stories are flaky in firefox" },
-        {
+      skip: {
+        "`MyComponent` doesn't support ie11": { in: 'ie11' },
+        "Loading stories are flaky in firefox": { in: 'firefox', stories: 'Loading' },
+        "`MyComponent` hovering doesn't work correctly": {
           in: ['firefox', 'chrome'],
           tests: /.*hover$/,
-          reason: "For some reason `MyComponent` hovering doesn't work correctly",
         },
-      ],
+      },
     },
   },
 } as Meta & CreeveyMeta;
@@ -169,44 +168,41 @@ Basic.parameters = {
 
 ```ts
 interface SkipOption {
-  reason?: string;
   in?: string | string[] | RegExp;
   kinds?: string | string[] | RegExp;
   stories?: string | string[] | RegExp;
   tests?: string | string[] | RegExp;
 }
 
-type SkipOptions = SkipOption | SkipOption[] | Record<string, SkipOption | SkipOption[]>;
+type SkipOptions = boolean | string | Record<string, SkipOption | SkipOption[]>;
 ```
 
 - Skip all stories for all browsers:
   - `skip: true`
   - `skip: 'Skip reason message'`
-  - `skip: { reason: 'Skip reason message' }`
+  - `skip: { 'Skip reason message': true }`
 - Skip all stories for specific browsers:
-  - `skip: { in: 'ie11' }`
-  - `skip: { in: ['ie11', 'chrome'] }`
-  - `skip: { in: /^fire.*/ }`
+  - `skip: { 'Skip reason message': { in: 'ie11' } }`
+  - `skip: { 'Skip reason message': { in: ['ie11', 'chrome'] } }`
+  - `skip: { 'Skip reason message': { in: /^fire.*/ } }`
 - Skip all stories in specific kinds:
-  - `skip: { kinds: 'Button' }`
-  - `skip: { kinds: ['Button', 'Input'] }`
-  - `skip: { kinds: /.*Modal$/ }`
+  - `skip: { 'Skip reason message': { kinds: 'Button' } }`
+  - `skip: { 'Skip reason message': { kinds: ['Button', 'Input'] } }`
+  - `skip: { 'Skip reason message': { kinds: /.*Modal$/ } }`
 - Skip all tests in specific stories:
-  - `skip: { stories: 'simple' }`
-  - `skip: { stories: ['simple', 'special'] }`
-  - `skip: { stories: /.*large$/ }`
+  - `skip: { 'Skip reason message': { stories: 'simple' } }`
+  - `skip: { 'Skip reason message': { stories: ['simple', 'special'] } }`
+  - `skip: { 'Skip reason message': { stories: /.*large$/ } }`
 - Skip specific tests:
-  - `skip: { tests: 'click' }`
-  - `skip: { tests: ['hover', 'click'] }`
-  - `skip: { tests: /^press.*$/ }`
+  - `skip: { 'Skip reason message': { tests: 'click' } }`
+  - `skip: { 'Skip reason message': { tests: ['hover', 'click'] } }`
+  - `skip: { 'Skip reason message': { tests: /^press.*$/ } }`
 - Multiple skip options:
-  - as an array `skip: [{ /* ... */ }]`
-  - as an object
-    ```
-    skip: {
-      foo: { /* ... */ },
-      bar: { /* ... */ },
-    }
-    ```
+  ```
+  skip: {
+    "reason 1": { /* ... */ },
+    "reason 2": { /* ... */ },
+  }
+  ```
 
 NOTE: If you try to skip stories by story name, the storybook name format will be used (For more info see [storybook-export-vs-name-handling](https://storybook.js.org/docs/formats/component-story-format/#storybook-export-vs-name-handling))

--- a/docs/config.md
+++ b/docs/config.md
@@ -198,11 +198,18 @@ type SkipOptions = boolean | string | Record<string, SkipOption | SkipOption[]>;
   - `skip: { 'Skip reason message': { tests: ['hover', 'click'] } }`
   - `skip: { 'Skip reason message': { tests: /^press.*$/ } }`
 - Multiple skip options:
-  ```
-  skip: {
-    "reason 1": { /* ... */ },
-    "reason 2": { /* ... */ },
-  }
-  ```
+  - for one reason
+    ```
+    skip: {
+      "reason": [{ /* ... */ }, { /* ... */ }],
+    }
+    ```
+  - for several reasons
+    ```
+    skip: {
+      "reason 1": { /* ... */ },
+      "reason 2": { /* ... */ },
+    }
+    ```
 
 NOTE: If you try to skip stories by story name, the storybook name format will be used (For more info see [storybook-export-vs-name-handling](https://storybook.js.org/docs/formats/component-story-format/#storybook-export-vs-name-handling))

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -34,30 +34,32 @@ export function shouldSkip(
   if (typeof skipOptions != 'object') {
     return skipOptions;
   }
-  if (Array.isArray(skipOptions)) {
-    for (const skip of skipOptions) {
-      const reason = shouldSkip(browser, meta, skip, test);
-      if (reason) return reason;
+  for (const skipKey in skipOptions) {
+    const reason = shouldSkipByOption(browser, meta, skipOptions[skipKey], skipKey, test);
+    if (reason) return reason;
+  }
+  return false;
+}
+
+export function shouldSkipByOption(
+  browser: string,
+  meta: {
+    kind: string;
+    story: string;
+  },
+  skipOption: SkipOption | SkipOption[],
+  reason: string,
+  test?: string,
+): string | boolean {
+  if (Array.isArray(skipOption)) {
+    for (const skip of skipOption) {
+      const result = shouldSkipByOption(browser, meta, skip, reason, test);
+      if (result) return result;
     }
     return false;
   }
-  let hasSkipOptionKeys = false;
-  for (const skipKey in skipOptions) {
-    if (skipOptionKeys.includes(skipKey)) {
-      hasSkipOptionKeys = true;
-      continue;
-    }
-    const reason = shouldSkip(
-      browser,
-      meta,
-      { reason: skipKey, ...(skipOptions as Record<string, SkipOption | SkipOption[]>)[skipKey] },
-      test,
-    );
-    if (reason) return reason;
-  }
-  if (!hasSkipOptionKeys) return false;
 
-  const { in: browsers, kinds, stories, tests, reason = true } = skipOptions as SkipOption;
+  const { in: browsers, kinds, stories, tests } = skipOption;
   const { kind, story } = meta;
   const skipByBrowser = matchBy(browsers, browser);
   const skipByKind = matchBy(kinds, kind);

--- a/src/types.ts
+++ b/src/types.ts
@@ -373,14 +373,13 @@ export interface CreeveyUpdate {
 }
 
 export interface SkipOption {
-  reason?: string;
   in?: string | string[] | RegExp;
   kinds?: string | string[] | RegExp;
   stories?: string | string[] | RegExp;
   tests?: string | string[] | RegExp;
 }
 
-export type SkipOptions = boolean | string | SkipOption | SkipOption[] | Record<string, SkipOption | SkipOption[]>;
+export type SkipOptions = boolean | string | Record<string, SkipOption | SkipOption[]>;
 
 export type CreeveyTestFunction = (this: {
   browser: WebDriver;

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -149,16 +149,11 @@ describe('shouldSkip', () => {
     });
   });
   describe('object', () => {
-    it('plain object without reason', () => {
-      const result = shouldSkip('chrome', { kind: 'Button', story: 'with Error' }, { tests: 'click' }, 'click');
-
-      expect(result).to.equal(true);
-    });
-    it('plain object with reason', () => {
+    it('plain object', () => {
       const result = shouldSkip(
         'chrome',
         { kind: 'Button', story: 'with Error' },
-        { tests: 'click', reason: 'Skip click tests' },
+        { 'Skip click tests': { tests: 'click' } },
         'click',
       );
 
@@ -169,10 +164,7 @@ describe('shouldSkip', () => {
         'chrome',
         { kind: 'Button', story: 'with Error' },
         {
-          Stories: [
-            { tests: 'click', reason: 'Skip click tests' },
-            { tests: 'fillIn', reason: 'Skip fillIn tests' },
-          ],
+          'Skip click tests': [{ tests: 'click' }, { tests: 'fillIn' }],
         },
         'click',
       );
@@ -184,26 +176,13 @@ describe('shouldSkip', () => {
         'chrome',
         { kind: 'Button', story: 'with Error' },
         {
-          Button: { tests: 'click', reason: 'Skip click tests' },
-          Input: { tests: 'fillIn', reason: 'Skip fillIn tests' },
+          'Skip click tests': { tests: 'click' },
+          'Skip fillIn tests': { tests: 'fillIn' },
         },
         'click',
       );
 
       expect(result).to.equal('Skip click tests');
-    });
-    it('merged old and new formats', () => {
-      const skipOptions = {
-        Button: { in: 'chrome', tests: 'click', reason: 'Skip click tests' },
-        in: 'firefox',
-        tests: 'fillIn',
-        reason: 'Skip fillIn tests',
-      };
-      const result1 = shouldSkip('chrome', { kind: 'Button', story: 'with Error' }, skipOptions, 'click');
-      const result2 = shouldSkip('firefox', { kind: 'Input', story: 'with Error' }, skipOptions, 'fillIn');
-
-      expect(result1).to.equal('Skip click tests');
-      expect(result2).to.equal('Skip fillIn tests');
     });
   });
 });


### PR DESCRIPTION

**TLDR**: Now the only supported value types for the `skip` parameter are `boolean`, `string` or a `Record` with the reason in keys and `SkipOption` in values, e.g.:
```ts
{
  creevey: {
    skip: true,
    // or
    skip: 'too flacky',
    // or
    skip: {
      'flacky in ie11': { in: 'ie11' },
    }
  }
}
```


```diff
diff --git a/src/types.ts b/src/types.ts
index 3263ba4..95cf6b2 100644
--- a/src/types.ts
+++ b/src/types.ts
@@ -373,14 +373,13 @@ export interface CreeveyUpdate {
 }
 
 export interface SkipOption {
-  reason?: string;
   in?: string | string[] | RegExp;
   kinds?: string | string[] | RegExp;
   stories?: string | string[] | RegExp;
   tests?: string | string[] | RegExp;
 }
 
-export type SkipOptions = boolean | string | SkipOption | SkipOption[] | Record<string, SkipOption | SkipOption[]>;
+export type SkipOptions = boolean | string | Record<string, SkipOption | SkipOption[]>;  
 
 export type CreeveyTestFunction = (this: {
   browser: WebDriver;
```

---

Hi, 
I found a problem with current skips format. Consider a stories file like this:

```jsx
export default {
  title: 'Button',
  parameters: {
    creevey: {
      skip: { in: 'ie11', tests: 'hover' },
    },
  }
}

export Story = () => '...';
Story.parameters = {
  creevey: {
    skip: { in: 'ie11' },
  }
}
```

It's expected that Story's screenshot will be skipped in 'ie11'. But with `storybook@6.4+` and `creevey@0.8.0-beta.0` it won't. 

This happens because of current storybook's parameters merging strategy. It merges object together by itself. In result, the Story ends up with next parameters. And it is not what was expected.
```js
{
  creevey: {
    skip: { in: 'ie11', tests: 'hover' },
  }
}
```

As a simple solution I suggest forbidding objects of type `SkipOption` on the root skip level. So that, if its an object in the root (like, `{ skip: {...} }`), its only a `Record<string, SkipOption | SkipOption[]>`, which is more safe to merge with other such records. 

This way users may still face those merging problems if record keys are not unique among different parameters levels. But this time its on them to provide unique keys. 
