### PR TITLE
fix: deps issue with storybook@6.5 and yarn@1

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "@storybook/channels": "^6.5.9",
     "@storybook/client-api": "^6.5.9",
     "@storybook/client-logger": "^6.5.9",
-    "@storybook/core": "^6.5.9",
     "@storybook/core-client": "^6.5.9",
     "@storybook/core-common": "^6.5.9",
     "@storybook/core-events": "^6.5.9",

--- a/src/server/loaders/webpack/compile.ts
+++ b/src/server/loaders/webpack/compile.ts
@@ -241,7 +241,7 @@ export default async function compile(config: Config, { debug, ui }: Options): P
     }),
     // TODO Don't work well with monorepos
     nodeExternals({
-      modulesDir: resolveFromStorybook('@storybook/core').split('@storybook')[0],
+      modulesDir: resolveFromStorybook('@storybook/core-client').split('@storybook')[0],
       includeAbsolutePaths: true,
       allowlist: /(webpack|dummy-hmr|generated-stories-entry|generated-config-entry|generated-other-entry)/,
     }),

--- a/src/server/storybook/entry.ts
+++ b/src/server/storybook/entry.ts
@@ -4,7 +4,7 @@ import { getStorybookFramework, resolveFromStorybook } from './helpers';
 
 const framework = getStorybookFramework();
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const core = require(resolveFromStorybook('@storybook/core')) as typeof import('@storybook/core');
+const core = require(resolveFromStorybook('@storybook/core-client')) as typeof import('@storybook/core-client');
 
 const start = core.start;
 const api = start(() => void 0);

--- a/src/server/storybook/helpers.ts
+++ b/src/server/storybook/helpers.ts
@@ -28,8 +28,8 @@ export const resolveFromStorybookAddonDocs = (modulePath: string): string =>
   resolveFrom(resolveFromStorybook('@storybook/addon-docs'), modulePath);
 export const resolveFromStorybookBuilderWebpack4 = (modulePath: string): string =>
   resolveFrom(resolveFromStorybook('@storybook/builder-webpack4'), modulePath);
-export const resolveFromStorybookCore = (modulePath: string): string =>
-  resolveFrom(resolveFromStorybook('@storybook/core'), modulePath);
+export const resolveFromStorybookCoreClient = (modulePath: string): string =>
+  resolveFrom(resolveFromStorybook('@storybook/core-client'), modulePath);
 export const resolveFromStorybookCoreServer = (modulePath: string): string =>
   resolveFrom(resolveFromStorybook('@storybook/core-server'), modulePath);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,7 +2330,7 @@
     ws "^8.2.3"
     x-default-browser "^0.4.0"
 
-"@storybook/core@6.5.9", "@storybook/core@^6.5.9":
+"@storybook/core@6.5.9":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/core/-/core-6.5.9.tgz#da4f237391d99aed1228323f24b335cafbdf3499"
   integrity sha512-Mt3TTQnjQt2/pa60A+bqDsAOrYpohapdtt4DDZEbS8h0V6u11KyYYh3w7FCySlL+sPEyogj63l5Ec76Jah3l2w==


### PR DESCRIPTION
After upgrading to `storybook@6.5.16` I started to face the next error:

![image](https://user-images.githubusercontent.com/4607770/215988351-dff44877-44ba-4a05-aa15-3f0db9cc8a38.png)

It's comming from that line
https://github.com/creevey/creevey/blob/4ce669e7cee58af3bfc8b8fe09d8b31559512b01/src/server/storybook/entry.ts#L7

which tries to resolve the `@storybook/core` package relative to the users's storybook config dir. And Creevey reasonably assumes that the package will be available there. Well, in most cases it is.

But in my project that uses `yarn@1` there is one problem with deps hoisting. My actual `node_modules` dir looks like this:

```
/packages/.../.storybook
/node_modules
    |--@storybook
    |    |--core-server
    |    |--core-client
    |    ...
    |    |--react
    |        |--node_modules
    |            |--core
```
So, for some reason `@storybook/core` doesn't get hoisted to `/node_modules`. And this is probably the reason of the above error.

It seems like a yarn's issue. With `npm@8` in the same project everything is fine. And I've not found a proper solution for it.

---

But there will be a workaround if we consider next change. Actually `@storybook/core` now exists only for [compatibility](https://github.com/storybookjs/storybook/tree/v6.5.16/lib/core) reasons. It not longer exists in [storybook@7](https://github.com/storybookjs/storybook/tree/v7.0.0-beta.38/code/lib). It's dependends are switching to direct usage of [@storybook/core-client](https://github.com/storybookjs/storybook/blob/v7.0.0-beta.38/code/renderers/react/package.json#L52). Why should not we do the same thing?