### PR TITLE
fix(addon): make bundlers to load esm version of addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.8.1-beta.0](https://github.com/wKich/creevey/compare/v0.8.0...v0.8.1-beta.0) (2023-04-11)
+
+### Bug Fixes
+
+- **addon:** make bundlers to load esm version of addon ([f2937ca](https://github.com/wKich/creevey/commit/f2937caccca158e68c8be45d0882ec9b62eb05b2))
+
 # [0.8.0](https://github.com/wKich/creevey/compare/v0.8.0-beta.1...v0.8.0) (2023-03-07)
 
 ### Bug Fixes

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,4 +1,5 @@
 {
   "main": "../lib/cjs/client/addon/index.js",
+  "module": "../lib/esm/client/addon/index.js",
   "types": "../lib/types/client/addon/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "addon",
     "test"
   ],
-  "version": "0.8.0",
+  "version": "0.8.1-beta.0",
   "bin": {
     "creevey": "./lib/cjs/cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     },
     "./addon": {
       "types": "./lib/types/client/addon/index.d.ts",
+      "module": "./lib/esm/client/addon/index.js",
       "default": "./lib/cjs/client/addon/index.js"
     },
     "./preset": "./preset/index.js",


### PR DESCRIPTION
Hi,

I faced a situation when the following import within a story leads to the `withCreevey` module being bundled twice, both in `cjs` and `esm` versions.

```js
import { capture } from 'creevey/addon';
```

The `esm` version gets loaded by storybook during the addon initialization. And the `cjs` version gets loaded by the import above, since the proper export declaration is missing in the package. The PR fixes that.

This duplication causes the `capture` to not work. The reason is the variables `isTestBrowser` and `captureResolver` never gets set in `cjs` version of addon. 

Tested with node@16.15.1 and builders:
- [x] webpack@4
- [x] webpack@5
- [ ] vite (trying to set up)

PS: Webpack@4 doesn't support the `exports` field. Webpack@5 docs about it can be found [here](https://webpack.js.org/guides/package-exports/).
