### PR TITLE
fix: allow using "capture"  with nodejsStoriesProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.8.1-beta.1](https://github.com/wKich/creevey/compare/v0.8.1-beta.0...v0.8.1-beta.1) (2023-05-05)
+
+### Bug Fixes
+
+- **providers:** set creevey port for all providers ([79e8aae](https://github.com/wKich/creevey/commit/79e8aae629d79260f93a93057486bab659801a46))
+
 ## [0.8.1-beta.0](https://github.com/wKich/creevey/compare/v0.8.0...v0.8.1-beta.0) (2023-04-11)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "addon",
     "test"
   ],
-  "version": "0.8.1-beta.0",
+  "version": "0.8.1-beta.1",
   "bin": {
     "creevey": "./lib/cjs/cli.js"
   },

--- a/src/server/storybook/providers/nodejs.ts
+++ b/src/server/storybook/providers/nodejs.ts
@@ -2,7 +2,7 @@
 import path from 'path';
 import cluster from 'cluster';
 import chokidar, { FSWatcher } from 'chokidar';
-import type { StoryInput, WebpackMessage, SetStoriesData, Config, StoriesRaw } from '../../../types';
+import type { StoryInput, WebpackMessage, SetStoriesData, Config, StoriesRaw, StoriesProvider } from '../../../types';
 import { noop } from '../../../types';
 import { getCreeveyCache } from '../../utils';
 import { subscribeOn } from '../../messages';
@@ -161,11 +161,7 @@ async function loadStoriesDirectly(
 }
 
 // TODO Do we need to support multiple storybooks here?
-export async function loadStories(
-  config: Config,
-  { watch, debug }: { watch: boolean; debug: boolean },
-  storiesListener: (stories: Map<string, StoryInput[]>) => void,
-): Promise<StoriesRaw> {
+export const loadStories: StoriesProvider = async (config, { watch, debug }, storiesListener) => {
   const storybookApi = await initStorybookEnvironment();
   const Events = await importStorybookCoreEvents();
 
@@ -191,7 +187,7 @@ export async function loadStories(
   else void loadStoriesDirectly(config, { watcher, debug });
 
   return loadPromise;
-}
+};
 
 export async function extractStoriesData(
   config: Config,

--- a/src/server/worker/worker.ts
+++ b/src/server/worker/worker.ts
@@ -140,7 +140,7 @@ export default async function worker(config: Config, options: Options & { browse
 
   chai.use(chaiImage(getExpected, config.diffOptions));
 
-  if ((await getBrowser(config, options.browser)) == null) return;
+  if ((await getBrowser(config, options)) == null) return;
 
   await addTestsFromStories(mocha.suite, config, {
     browser: options.browser,
@@ -150,11 +150,11 @@ export default async function worker(config: Config, options: Options & { browse
   });
 
   try {
-    await (await getBrowser(config, options.browser))?.getCurrentUrl();
+    await (await getBrowser(config, options))?.getCurrentUrl();
   } catch (_) {
     await closeBrowser();
   }
-  const browser = await getBrowser(config, options.browser);
+  const browser = await getBrowser(config, options);
   const sessionId = (await browser?.getSession())?.getId();
 
   if (browser == null) return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,11 +218,7 @@ export interface Config {
    * }
    * ```
    */
-  storiesProvider: (
-    config: Config,
-    options: { watch: boolean; debug: boolean; port: number },
-    storiesListener: (stories: Map<string, StoryInput[]>) => void,
-  ) => Promise<StoriesRaw>;
+  storiesProvider: StoriesProvider;
   /**
    * Define custom babel options for load stories transformation
    */
@@ -257,6 +253,12 @@ export interface Config {
    */
   dockerImagePlatform: string;
 }
+
+export type StoriesProvider = (
+  config: Config,
+  options: { watch: boolean; debug: boolean },
+  storiesListener: (stories: Map<string, StoryInput[]>) => void,
+) => Promise<StoriesRaw>;
 
 export type CreeveyConfig = Partial<Config>;
 


### PR DESCRIPTION
Hi,

Right now it's possible to use `capture` function only  with `browserStoriesProvider`, since the neccessary `creeveyPort` and `creeveyHost` get set within it. Is there any reason for not using the `capture` with `nodejsStoriesProvider`?

I suggest setting neccessary params for all browsers. It will allow using `сapture` with any provider.