### PR TITLE
Add autostart storybook feature via `storybookAutorunCmd`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -47,6 +47,9 @@ module.exports = {
   // Default Storybook url
   storybookUrl: 'http://localhost:6006',
 
+  // Command to automatically start Storybook if it is not running
+  storybookAutorunCmd: 'yarn storybook',
+
   // Where original images are stored
   screenDir: path.join(__dirname, '../images'),
 

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -72,6 +72,7 @@ export async function readConfig(options: Options): Promise<Config> {
   if (options.reportDir) userConfig.reportDir = path.resolve(options.reportDir);
   if (options.screenDir) userConfig.screenDir = path.resolve(options.screenDir);
   if (options.storybookUrl) userConfig.storybookUrl = options.storybookUrl;
+  if (options.storybookAutorunCmd) userConfig.storybookAutorunCmd = options.storybookAutorunCmd;
 
   // NOTE: Hack to pass typescript checking
   const config = userConfig as Config;

--- a/src/server/storybook/connection.ts
+++ b/src/server/storybook/connection.ts
@@ -8,7 +8,7 @@ const RESPONSE_CHECK_TIMEOUT_MS = 10000;
 const RESPONSE_CHECK_INTERVAL_MS = 200;
 
 export async function getStorybookUrl({ storybookUrl, resolveStorybookUrl }: Config) {
-  return storybookUrl ? storybookUrl : resolveStorybookUrl?.();
+  return resolveStorybookUrl ? resolveStorybookUrl() : storybookUrl;
 }
 
 export async function tryAutorunStorybook(url: string, storybookAutorunCmd: string) {

--- a/src/server/storybook/connection.ts
+++ b/src/server/storybook/connection.ts
@@ -7,22 +7,22 @@ const RESPONSE_FAST_CHECK_TIMEOUT_MS = 3000;
 const RESPONSE_CHECK_TIMEOUT_MS = 10000;
 const RESPONSE_CHECK_INTERVAL_MS = 200;
 
-export async function tryAutorunStorybook({ storybookAutorunCmd, storybookUrl }: Config) {
-  if (!storybookAutorunCmd) {
-    return;
-  }
+export async function getStorybookUrl({ storybookUrl, resolveStorybookUrl }: Config) {
+  return storybookUrl ? storybookUrl : resolveStorybookUrl?.();
+}
 
+export async function tryAutorunStorybook(url: string, storybookAutorunCmd: string) {
   try {
-    await waitOnUrl(storybookUrl, RESPONSE_FAST_CHECK_TIMEOUT_MS, RESPONSE_CHECK_INTERVAL_MS);
+    await waitOnUrl(url, RESPONSE_FAST_CHECK_TIMEOUT_MS, RESPONSE_CHECK_INTERVAL_MS);
   } catch {
     logger().info(`Trying start Storybook automatically via \`${storybookAutorunCmd}\` from config...`);
     exec(storybookAutorunCmd);
   }
 }
 
-export async function checkIsStorybookConnected({ storybookUrl }: Config) {
+export async function checkIsStorybookConnected(url: string) {
   try {
-    await waitOnUrl(storybookUrl, RESPONSE_CHECK_TIMEOUT_MS, RESPONSE_CHECK_INTERVAL_MS);
+    await waitOnUrl(url, RESPONSE_CHECK_TIMEOUT_MS, RESPONSE_CHECK_INTERVAL_MS);
     return true;
   } catch (reason: unknown) {
     const error = reason instanceof Error ? (reason.stack ?? reason.message) : (reason as string);

--- a/src/server/storybook/connection.ts
+++ b/src/server/storybook/connection.ts
@@ -1,0 +1,32 @@
+import { Config } from 'src/types';
+import { waitOnUrl } from '../utils';
+import { logger } from '../logger';
+import { exec } from 'node:child_process';
+
+const RESPONSE_FAST_CHECK_TIMEOUT_MS = 3000;
+const RESPONSE_CHECK_TIMEOUT_MS = 10000;
+const RESPONSE_CHECK_INTERVAL_MS = 200;
+
+export async function tryAutorunStorybook({ storybookAutorunCmd, storybookUrl }: Config) {
+  if (!storybookAutorunCmd) {
+    return;
+  }
+
+  try {
+    await waitOnUrl(storybookUrl, RESPONSE_FAST_CHECK_TIMEOUT_MS, RESPONSE_CHECK_INTERVAL_MS);
+  } catch {
+    logger().info(`Trying start Storybook automatically via \`${storybookAutorunCmd}\` from config...`);
+    exec(storybookAutorunCmd);
+  }
+}
+
+export async function checkIsStorybookConnected({ storybookUrl }: Config) {
+  try {
+    await waitOnUrl(storybookUrl, RESPONSE_CHECK_TIMEOUT_MS, RESPONSE_CHECK_INTERVAL_MS);
+    return true;
+  } catch (reason: unknown) {
+    const error = reason instanceof Error ? (reason.stack ?? reason.message) : (reason as string);
+    logger().error(error);
+    return false;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,14 +143,14 @@ export interface Config {
    */
   storybookUrl: string;
   /**
+   * Url where storybook hosted on
+   */
+  resolveStorybookUrl?: () => Promise<string>;
+  /**
    * Command to automatically start Storybook if it is not running.
    * For example, `npm run storybook`, `yarn run storybook` etc.
    */
   storybookAutorunCmd?: string;
-  /**
-   * Url where storybook hosted on
-   */
-  resolveStorybookUrl?: () => Promise<string>;
   /**
    * Absolute path to directory with reference images
    * @default path.join(process.cwd(), './images')

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,11 @@ export interface Config {
    */
   storybookUrl: string;
   /**
+   * Command to automatically start Storybook if it is not running.
+   * For example, `npm run storybook`, `yarn run storybook` etc.
+   */
+  storybookAutorunCmd?: string;
+  /**
    * Url where storybook hosted on
    */
   resolveStorybookUrl?: () => Promise<string>;
@@ -276,6 +281,7 @@ export interface Options {
   screenDir?: string;
   reportDir?: string;
   storybookUrl?: string;
+  storybookAutorunCmd?: string;
   saveReport: boolean;
   failFast?: boolean;
 }


### PR DESCRIPTION
Hi! I added two features that improve DX Creevey for first-time users!

1. I added startup messages that indicate that Storybook needs to be run in parallel. And send an error if the Storybook is not started within 10 seconds of startup.

2. I added a `storybookAutorunCmd` parameter to the config that automatically starts the storybook if needed.


## Examples

### With `storybookAutorunCmd`

https://github.com/user-attachments/assets/e6747cff-9a6d-41b1-98ae-0040f091b85c

### Without `storybookAutorunCmd`

https://github.com/user-attachments/assets/fcf79f91-5f85-42e2-b4a8-ba578279590c

