### PR TITLE
feat: devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/typescript-node:20
+
+RUN yarn set version stable
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "image": "mcr-proxy.kontur.host/devcontainers/typescript-node:20",
+  "updateRemoteUserUID": true
+}
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
-  "image": "mcr-proxy.kontur.host/devcontainers/typescript-node:20",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
   "updateRemoteUserUID": true
 }
 


### PR DESCRIPTION
Add [devcontainer](https://containers.dev/) support to creevey to simplify the development environment.